### PR TITLE
Add Gen Interface JP to Subordinate Latin

### DIFF
--- a/subordinate-latin.html
+++ b/subordinate-latin.html
@@ -33,6 +33,8 @@
     })(document);
   </script>
 
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@0.6.2/cdn/all.css" />
+
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Sawarabi+Mincho&family=Shippori+Mincho&family=Zen+Old+Mincho&family=Hina+Mincho&family=Zen+Old+Mincho&family=Noto+Sans+JP&family=Noto+Serif+JP&family=BIZ+UDMincho&family=Yuji+Syuku&display=swap');
 
@@ -710,6 +712,7 @@
     { fontFamily: "MS PGothic", platform: "Windows", style: "sans serif", link: "https://learn.microsoft.com/en-us/typography/font-list/ms-pgothic" },
     { fontFamily: "Meiryo", platform: "Windows", style: "sans serif", supportsFullWidth: true, supportsHalfWidth: true, link: "https://learn.microsoft.com/en-us/typography/font-list/meiryo" },
     { fontFamily: "Noto Sans JP", platform: "Google Fonts / Android", style: "sans serif", link: "https://fonts.google.com/noto/specimen/Noto+Sans+JP", supportsFullWidth: false, supportsHalfWidth: false, notes: ['c'] },
+    { name: "Gen Interface JP", fontFamily: "Gen Interface JP", platform: "gen.typesetting.jp", style: "sans serif", link: "https://gen.typesetting.jp/" },
     { fontFamily: "Osaka", platform: "MacOS", style: "sans serif" },
     { fontFamily: "Hiragino Kaku Gothic Pro", platform: "MacOS, iOS", style: "sans serif", supportsFullWidth: true, supportsHalfWidth: true },
     { fontFamily: "Hiragino Maru Gothic ProN", platform: "MacOS, iOS", style: "sans serif", supportsFullWidth: true, supportsHalfWidth: true },


### PR DESCRIPTION
## Summary
- Adds [Gen Interface JP](https://gen.typesetting.jp/) to the Subordinate Latin font collection and type tester
- Loads the font via the official `gen-interface-jp` CDN stylesheet so samples render in-browser

## Test plan
- [ ] Open `subordinate-latin.html` locally or on the preview deploy
- [ ] Confirm Gen Interface JP appears in the sans-serif section of the type tester tables
- [ ] Confirm the specimen renders (not dingbats) and the font name links to https://gen.typesetting.jp/
- [ ] Spot-check the body font selector includes Gen Interface JP


Made with [Cursor](https://cursor.com)