### PR TITLE
Add descriptions to atom.xml entries, hide them in the ticker

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -35,7 +35,7 @@
         <link href="https://maxbo.me/is-in-the-internet-phone-book.html"/>
         <id>https://maxbo.me/is-in-the-internet-phone-book.html</id>
         <updated>2025-05-25T00:00:00Z</updated>
-        <summary></summary>
+        <summary>maxbo.me was listed in the Internet Phone Book, a printed directory of personal websites worth visiting.</summary>
         <author>
             <name>Max Bo</name>
         </author>
@@ -58,7 +58,7 @@
         <link href="https://maxbo.me/sanrio-character-rankings"/>
         <id>https://maxbo.me/sanrio-character-rankings</id>
         <updated>2025-01-24T00:00:00Z</updated>
-        <summary></summary>
+        <summary>A visualisation of how Sanrio characters rank in popularity across different countries.</summary>
         <author>
             <name>Max Bo</name>
         </author>
@@ -69,6 +69,7 @@
         <link href="https://maxbo.me/factorio"/>
         <id>https://maxbo.me/factorio</id>
         <updated>2025-01-10T00:00:00Z</updated>
+        <summary>A back-of-the-envelope analysis of whether gifting Factorio to your competitors' engineers is a cost-effective means of sabotage.</summary>
         <author>
             <name>Max Bo</name>
         </author>

--- a/index.html
+++ b/index.html
@@ -979,17 +979,11 @@
                 const title = item.getElementsByTagName('title')[0].textContent;
                 const link = item.getElementsByTagName('link')[0].getAttribute('href');
                 const updated = new Date(item.getElementsByTagName('updated')[0].textContent);
-                const summary = item.getElementsByTagName('summary')[0];
                 const shortDate = updated.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 
                 const a = document.createElement('a');
                 a.href = link;
                 a.textContent = `[${shortDate}] ${title}`;
-                if (summary) {
-                  const small = document.createElement('small');
-                  small.textContent = ` ${summary.textContent}`;
-                  a.appendChild(small);
-                }
                 ticker.appendChild(a);
                 ticker.appendChild(document.createTextNode(' ■ '));
               });


### PR DESCRIPTION
## Summary
- Filled in `<summary>` descriptions for the atom.xml entries that were missing them (*Internet Phone Book*, *Sanrio character rankings*, *Factorio sabotage*).
- Updated the `renderAtom` marquee ticker in `index.html` so it no longer appends summary text, keeping the ticker compact (`[date] title` only).

The descriptions still render in the XSL-styled feed view; they're just hidden from the scrolling ticker.

## Test plan
- [ ] Open `atom.xml` in a browser and confirm each entry shows its description.
- [ ] Load `index.html` and confirm the ticker shows only `[date] title` with no summaries.

Made with [Cursor](https://cursor.com)